### PR TITLE
Display renoted posts in timeline

### DIFF
--- a/apps/front/src/features/reactions/hooks/useNoteReactions.ts
+++ b/apps/front/src/features/reactions/hooks/useNoteReactions.ts
@@ -44,7 +44,7 @@ export function useNoteReactions({
   useEffect(() => {
     setMyReaction(note.myReaction ?? null);
     setReactionsMap({ ...(note.reactions || {}) });
-  }, [note.id, note.myReaction, note.reactions]);
+  }, [note.myReaction, note.reactions]);
 
   // Aggregated counts for list display (sorted)
   const reactionsWithCounts = useMemo(() => {

--- a/apps/front/src/features/timeline/components/MisskeyNote.test.tsx
+++ b/apps/front/src/features/timeline/components/MisskeyNote.test.tsx
@@ -207,6 +207,42 @@ describe("MisskeyNote", () => {
     expect(usernameElement).toHaveClass("text-muted-foreground");
   });
 
+  it("should show a link for nested renotes instead of rendering deeper previews", () => {
+    const origin = "misskey.example.com";
+    const originalNote = createMockNote({
+      id: "original-note",
+      text: "Original nested note",
+    });
+    const firstRenote = createMockNote({
+      id: "first-renote",
+      text: "First renote text",
+      renote: originalNote,
+    });
+    const doubleRenote = createMockNote({
+      id: "double-renote",
+      text: "Double renote text",
+      renote: firstRenote,
+    });
+
+    render(<MisskeyNote note={doubleRenote} origin={origin} />);
+
+    const renoteLink = screen.getByRole("link", {
+      name: "@testuserのノートを見る",
+    });
+
+    expect(renoteLink).toHaveAttribute(
+      "href",
+      "https://misskey.example.com/notes/original-note",
+    );
+
+    const textContents = screen
+      .getAllByTestId("mfm-text-content")
+      .map((element) => element?.textContent);
+
+    expect(textContents).toContain("First renote text");
+    expect(textContents).not.toContain("Original nested note");
+  });
+
   it("should render note text with MfmText", () => {
     const note = createMockNote({
       text: "Hello world :smile: test",

--- a/apps/front/src/features/timeline/components/MisskeyNote.tsx
+++ b/apps/front/src/features/timeline/components/MisskeyNote.tsx
@@ -28,7 +28,7 @@ function MisskeyNoteBase({ note, origin }: { note: Note; origin: string }) {
     <CustomEmojiCtx.Provider value={contextValue}>
       <article
         className={cn(
-          "flex gap-3 border-b p-3 transition-colors duration-200 hover:bg-muted/50",
+          "flex items-start gap-3 border-b p-3 transition-colors duration-200 hover:bg-muted/50",
         )}
       >
         <div>

--- a/apps/front/src/features/timeline/components/MisskeyNote.tsx
+++ b/apps/front/src/features/timeline/components/MisskeyNote.tsx
@@ -1,3 +1,4 @@
+import { Repeat2 } from "lucide-react";
 import type { Note } from "misskey-js/entities.js";
 import { memo, useMemo } from "react";
 import { CustomEmojiCtx } from "@/features/emoji";
@@ -33,7 +34,15 @@ function MisskeyNoteBase({ note, origin }: { note: Note; origin: string }) {
         <div>
           <MisskeyNoteHeader user={note.user} />
         </div>
-        <MisskeyNoteContent note={note} origin={origin} emojis={allEmojis} />
+        <div className="min-w-0 flex-1">
+          {note.renote && (
+            <div className="mb-1 flex items-center gap-1 text-muted-foreground text-xs">
+              <Repeat2 className="h-3.5 w-3.5" aria-hidden />
+              <span>Renote</span>
+            </div>
+          )}
+          <MisskeyNoteContent note={note} origin={origin} emojis={allEmojis} />
+        </div>
       </article>
     </CustomEmojiCtx.Provider>
   );
@@ -67,7 +76,8 @@ const areMisskeyNotePropsEqual = (
   if (
     prevProps.note.id !== nextProps.note.id ||
     prevProps.note.text !== nextProps.note.text ||
-    prevProps.origin !== nextProps.origin
+    prevProps.origin !== nextProps.origin ||
+    prevProps.note.renote?.id !== nextProps.note.renote?.id
   ) {
     return false;
   }

--- a/apps/front/src/features/timeline/components/MisskeyNoteContent.tsx
+++ b/apps/front/src/features/timeline/components/MisskeyNoteContent.tsx
@@ -134,7 +134,7 @@ function RenotePreview({
   return (
     <CustomEmojiCtx.Provider value={contextValue}>
       <div className="mt-2 rounded-md border bg-muted/40 p-3">
-        <div className="flex gap-3">
+        <div className="flex items-start gap-2">
           <MisskeyNoteHeader user={renote.user} />
           <MisskeyNoteContent
             note={renote}

--- a/apps/front/src/features/timeline/components/MisskeyNoteContent.tsx
+++ b/apps/front/src/features/timeline/components/MisskeyNoteContent.tsx
@@ -1,9 +1,12 @@
 import type { Note } from "misskey-js/entities.js";
-import { memo } from "react";
+import { memo, useMemo } from "react";
+import { CustomEmojiCtx } from "@/features/emoji";
 import { MfmText } from "@/features/mfm";
 import { ReactionButton } from "@/features/reactions/components/ReactionButton";
 import { cn } from "@/lib/utils";
 import { NoteReactions } from "../../reactions/components/NoteReactions";
+import { useNoteEmojis } from "../../reactions/hooks/useNoteEmojis";
+import { MisskeyNoteHeader } from "./MisskeyNoteHeader";
 
 interface MisskeyNoteContentProps {
   note: Note;
@@ -11,51 +14,85 @@ interface MisskeyNoteContentProps {
   emojis: Record<string, string>;
 }
 
-export const MisskeyNoteContent = memo(
-  ({ note, origin, emojis }: MisskeyNoteContentProps) => {
-    const user = note.user;
-    return (
-      <div className="flex w-full min-w-0 flex-col gap-1">
-        <div className="flex items-center gap-2">
-          <div className="flex items-center gap-2 text-sm">
-            <p>
-              <MfmText
-                text={user.name || user.username}
-                host={origin}
-                emojis={emojis}
-              />
-              <span className="text-muted-foreground">@{user.username}</span>
-            </p>
-          </div>
-        </div>
-        <div className="space-y-2">
-          {note.text && (
-            <MfmText text={note.text} host={origin} emojis={emojis} />
-          )}
-          {note.files && note.files.length > 0 && (
-            <div className="space-y-2">
-              {note.files.map((file) => (
-                <img
-                  key={file.id}
-                  src={file.url}
-                  alt="Note Attachment"
-                  className={cn("mt-2 h-auto max-w-full rounded-md border")}
-                />
-              ))}
-            </div>
-          )}
-          <NoteReactions
-            note={note}
-            origin={origin}
-            emojis={note.reactionEmojis}
-          />
-          <div className="flex items-center gap-2 pt-1">
-            <ReactionButton note={note} origin={origin} emojis={emojis} />
-          </div>
+function MisskeyNoteContentBase({
+  note,
+  origin,
+  emojis,
+}: MisskeyNoteContentProps) {
+  const user = note.user;
+  return (
+    <div className="flex w-full min-w-0 flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <p>
+            <MfmText
+              text={user.name || user.username}
+              host={origin}
+              emojis={emojis}
+            />
+            <span className="text-muted-foreground">@{user.username}</span>
+          </p>
         </div>
       </div>
-    );
-  },
-);
+      <div className="space-y-2">
+        {note.text && (
+          <MfmText text={note.text} host={origin} emojis={emojis} />
+        )}
+        {note.files && note.files.length > 0 && (
+          <div className="space-y-2">
+            {note.files.map((file) => (
+              <img
+                key={file.id}
+                src={file.url}
+                alt="Note Attachment"
+                className={cn("mt-2 h-auto max-w-full rounded-md border")}
+              />
+            ))}
+          </div>
+        )}
+        {note.renote ? (
+          <RenotePreview renote={note.renote} origin={origin} />
+        ) : null}
+        <NoteReactions
+          note={note}
+          origin={origin}
+          emojis={note.reactionEmojis}
+        />
+        <div className="flex items-center gap-2 pt-1">
+          <ReactionButton note={note} origin={origin} emojis={emojis} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const MisskeyNoteContent = memo(MisskeyNoteContentBase);
 
 MisskeyNoteContent.displayName = "MisskeyNoteContent";
+
+function RenotePreview({ renote, origin }: { renote: Note; origin: string }) {
+  const host = origin || "";
+  const { allEmojis } = useNoteEmojis(renote, origin);
+  const contextValue = useMemo(
+    () => ({
+      host,
+      emojis: allEmojis,
+    }),
+    [host, allEmojis],
+  );
+
+  return (
+    <CustomEmojiCtx.Provider value={contextValue}>
+      <div className="mt-2 rounded-md border bg-muted/40 p-3">
+        <div className="flex gap-3">
+          <MisskeyNoteHeader user={renote.user} />
+          <MisskeyNoteContent
+            note={renote}
+            origin={origin}
+            emojis={allEmojis}
+          />
+        </div>
+      </div>
+    </CustomEmojiCtx.Provider>
+  );
+}

--- a/apps/front/src/features/timeline/components/MisskeyNoteContent.tsx
+++ b/apps/front/src/features/timeline/components/MisskeyNoteContent.tsx
@@ -84,7 +84,7 @@ function RenotePreview({ renote, origin }: { renote: Note; origin: string }) {
   return (
     <CustomEmojiCtx.Provider value={contextValue}>
       <div className="mt-2 rounded-md border bg-muted/40 p-3">
-        <div className="flex gap-3">
+        <div className="flex items-start transition-colors duration-200 ">
           <MisskeyNoteHeader user={renote.user} />
           <MisskeyNoteContent
             note={renote}


### PR DESCRIPTION
## Summary
- show a renote indicator on timeline items and render the referenced note content inline
- add a nested preview that provides emoji context so renoted notes can display text, media, and reactions
- update the Misskey note memo comparison to rerender when the renote target changes

## Testing
- pnpm run front -- test *(fails: workspace package `@mi-deck/react-mfm` cannot be resolved in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22b7dd8948327b893aaa76f79c57c