### PR TITLE
feat(front): allow importing Misskey theme JSON

### DIFF
--- a/apps/front/index.html
+++ b/apps/front/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#ffffff" />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/apps/front/src/features/settings/components/ApplicationSettings.tsx
+++ b/apps/front/src/features/settings/components/ApplicationSettings.tsx
@@ -13,17 +13,18 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { SupportedLanguage } from "@/lib/i18n/types";
 import type { Theme } from "@/lib/storage/types";
 import { useTheme } from "@/lib/theme/context";
+import { MisskeyThemeImporter } from "./MisskeyThemeImporter";
 
 export function ApplicationSettings() {
   const { t, i18n } = useTranslation("settings");
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, customTheme } = useTheme();
 
   const handleLanguageChange = (value: string) => {
     void i18n.changeLanguage(value as SupportedLanguage);
   };
 
   const isValidTheme = (value: string): value is Theme => {
-    return ["light", "dark", "system"].includes(value);
+    return ["light", "dark", "system", "custom"].includes(value);
   };
 
   const handleThemeChange = (value: string) => {
@@ -38,26 +39,36 @@ export function ApplicationSettings() {
         <CardTitle>{t("applicationSettings")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <Label>{t("theme.title")}</Label>
-            <p className="text-muted-foreground text-sm">
-              {t("theme.description")}
-            </p>
+        <div className="space-y-4">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-0.5">
+              <Label>{t("theme.title")}</Label>
+              <p className="text-muted-foreground text-sm">
+                {t("theme.description")}
+              </p>
+            </div>
+            <ToggleGroup
+              type="single"
+              value={theme}
+              onValueChange={handleThemeChange}
+              variant="outline"
+              size="sm"
+            >
+              <ToggleGroupItem value="light">
+                {t("theme.light")}
+              </ToggleGroupItem>
+              <ToggleGroupItem value="dark">{t("theme.dark")}</ToggleGroupItem>
+              <ToggleGroupItem value="system">
+                {t("theme.system")}
+              </ToggleGroupItem>
+              {customTheme ? (
+                <ToggleGroupItem value="custom">
+                  {customTheme.name || t("theme.custom")}
+                </ToggleGroupItem>
+              ) : null}
+            </ToggleGroup>
           </div>
-          <ToggleGroup
-            type="single"
-            value={theme}
-            onValueChange={handleThemeChange}
-            variant="outline"
-            size="sm"
-          >
-            <ToggleGroupItem value="light">{t("theme.light")}</ToggleGroupItem>
-            <ToggleGroupItem value="dark">{t("theme.dark")}</ToggleGroupItem>
-            <ToggleGroupItem value="system">
-              {t("theme.system")}
-            </ToggleGroupItem>
-          </ToggleGroup>
+          <MisskeyThemeImporter />
         </div>
 
         <Separator />

--- a/apps/front/src/features/settings/components/MisskeyThemeImporter.tsx
+++ b/apps/front/src/features/settings/components/MisskeyThemeImporter.tsx
@@ -1,0 +1,178 @@
+import { type ChangeEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { useTheme } from "@/lib/theme/context";
+
+const getErrorMessageKey = (error: unknown): string => {
+  if (!(error instanceof Error)) {
+    return "unknown";
+  }
+
+  switch (error.message) {
+    case "INVALID_JSON":
+      return "invalidJson";
+    case "INVALID_DATA":
+      return "invalidData";
+    case "INVALID_BASE":
+      return "invalidBase";
+    case "INVALID_PROPS":
+      return "invalidProps";
+    case "EMPTY_PROPS":
+      return "emptyProps";
+    default:
+      return "unknown";
+  }
+};
+
+export function MisskeyThemeImporter() {
+  const { t } = useTranslation("settings");
+  const { toast } = useToast();
+  const { importMisskeyTheme, clearCustomTheme, customTheme } = useTheme();
+  const [jsonInput, setJsonInput] = useState("");
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [errorKey, setErrorKey] = useState<string | null>(null);
+
+  const handleImport = async (sourceJson?: string) => {
+    const payload = sourceJson ?? jsonInput;
+    if (!payload.trim()) {
+      setErrorKey("required");
+      return;
+    }
+
+    setIsProcessing(true);
+    setErrorKey(null);
+    try {
+      const theme = await importMisskeyTheme(payload);
+      setJsonInput("");
+      toast({
+        title: t("theme.import.successTitle"),
+        description: t("theme.import.successDescription", { name: theme.name }),
+      });
+    } catch (error) {
+      const key = getErrorMessageKey(error);
+      setErrorKey(key);
+      if (key === "unknown") {
+        toast({
+          title: t("theme.import.errorTitle"),
+          description: t("theme.import.errors.unknown"),
+        });
+      }
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      await handleImport(text);
+    } catch (error) {
+      const key = getErrorMessageKey(error);
+      setErrorKey(key);
+      toast({
+        title: t("theme.import.errorTitle"),
+        description:
+          key === "unknown"
+            ? t("theme.import.errors.unknown")
+            : t(`theme.import.errors.${key}`),
+      });
+    } finally {
+      event.target.value = "";
+    }
+  };
+
+  const handleClear = async () => {
+    setIsProcessing(true);
+    setErrorKey(null);
+    try {
+      await clearCustomTheme();
+      toast({
+        title: t("theme.import.clearTitle"),
+        description: t("theme.import.clearDescription"),
+      });
+    } catch (error) {
+      const key = getErrorMessageKey(error);
+      setErrorKey(key);
+      toast({
+        title: t("theme.import.errorTitle"),
+        description:
+          key === "unknown"
+            ? t("theme.import.errors.unknown")
+            : t(`theme.import.errors.${key}`),
+      });
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <Label>{t("theme.import.title")}</Label>
+        <p className="text-muted-foreground text-sm">
+          {t("theme.import.description")}
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Input
+          type="file"
+          accept="application/json"
+          onChange={handleFileChange}
+          disabled={isProcessing}
+          aria-label={t("theme.import.upload")}
+        />
+        <Textarea
+          value={jsonInput}
+          onChange={(event) => {
+            setJsonInput(event.target.value);
+            setErrorKey(null);
+          }}
+          placeholder={t("theme.import.placeholder") ?? undefined}
+          className="min-h-32"
+        />
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            onClick={() => void handleImport()}
+            disabled={isProcessing || jsonInput.trim().length === 0}
+          >
+            {isProcessing
+              ? t("theme.import.processing")
+              : t("theme.import.button")}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void handleClear()}
+            disabled={isProcessing || !customTheme}
+          >
+            {t("theme.import.clearButton")}
+          </Button>
+        </div>
+        {customTheme ? (
+          <p className="text-muted-foreground text-xs">
+            {t("theme.import.current", {
+              name: customTheme.name,
+              base: t(`theme.import.base.${customTheme.base}`),
+            })}
+          </p>
+        ) : (
+          <p className="text-muted-foreground text-xs">
+            {t("theme.import.noTheme")}
+          </p>
+        )}
+        {errorKey ? (
+          <p className="text-destructive text-sm">
+            {t(`theme.import.errors.${errorKey}`)}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/front/src/lib/storage/database.ts
+++ b/apps/front/src/lib/storage/database.ts
@@ -228,6 +228,7 @@ class DatabaseManager {
         theme: "system",
         language: "ja",
         lastUpdated: new Date(),
+        customTheme: undefined,
       };
     }
     return settings;
@@ -249,6 +250,7 @@ class DatabaseManager {
       theme: "system",
       language: "ja",
       lastUpdated: new Date(),
+      customTheme: undefined,
       ...currentSettings,
       ...updates,
     };

--- a/apps/front/src/lib/storage/localStorage.ts
+++ b/apps/front/src/lib/storage/localStorage.ts
@@ -245,6 +245,7 @@ class LocalStorageManager {
           theme: "system",
           language: "ja",
           lastUpdated: new Date(),
+          customTheme: undefined,
         };
       }
 
@@ -260,6 +261,7 @@ class LocalStorageManager {
         theme: "system",
         language: "ja",
         lastUpdated: new Date(),
+        customTheme: undefined,
       };
     }
   }
@@ -284,6 +286,7 @@ class LocalStorageManager {
         theme: "system",
         language: "ja",
         lastUpdated: new Date(),
+        customTheme: undefined,
         ...currentSettings,
         ...updates,
       };

--- a/apps/front/src/lib/storage/types.ts
+++ b/apps/front/src/lib/storage/types.ts
@@ -37,12 +37,21 @@ export interface TimelineConfig {
   updatedAt: Date;
 }
 
-export type Theme = "light" | "dark" | "system";
+export type Theme = "light" | "dark" | "system" | "custom";
+
+export interface MisskeyThemeSetting {
+  name: string;
+  base: "light" | "dark";
+  props: Record<string, string>;
+  author?: string;
+  description?: string;
+}
 
 export interface AppSettings {
   theme: Theme;
   language: string;
   lastUpdated: Date;
+  customTheme?: MisskeyThemeSetting;
 }
 
 export interface ClientAuthState {

--- a/apps/front/src/lib/theme/context.tsx
+++ b/apps/front/src/lib/theme/context.tsx
@@ -1,11 +1,18 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { useStorage } from "@/lib/storage/context";
-import type { Theme } from "@/lib/storage/types";
+import type { MisskeyThemeSetting, Theme } from "@/lib/storage/types";
+import {
+  createCssVariablesFromMisskeyTheme,
+  parseMisskeyTheme,
+} from "./misskey";
 
 interface ThemeContextType {
   theme: Theme;
   setTheme: (theme: Theme) => void;
   actualTheme: "light" | "dark";
+  customTheme?: MisskeyThemeSetting;
+  importMisskeyTheme: (json: string) => Promise<MisskeyThemeSetting>;
+  clearCustomTheme: () => Promise<void>;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -25,11 +32,14 @@ interface ThemeProviderProps {
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const { appSettings, updateAppSettings } = useStorage();
   const [actualTheme, setActualTheme] = useState<"light" | "dark">("light");
+  const appliedVariablesRef = React.useRef<string[]>([]);
+  const defaultThemeColorRef = React.useRef<string | null>(null);
 
   const theme = appSettings?.theme || "system";
+  const customTheme = appSettings?.customTheme;
 
   const isValidTheme = (value: string): value is Theme => {
-    return ["light", "dark", "system"].includes(value);
+    return ["light", "dark", "system", "custom"].includes(value);
   };
 
   useEffect(() => {
@@ -38,6 +48,12 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         return window.matchMedia("(prefers-color-scheme: dark)").matches
           ? "dark"
           : "light";
+      }
+      if (theme === "custom") {
+        if (customTheme?.base === "dark") {
+          return "dark";
+        }
+        return "light";
       }
       return theme;
     };
@@ -61,7 +77,57 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       mediaQuery.addEventListener("change", updateActualTheme);
       return () => mediaQuery.removeEventListener("change", updateActualTheme);
     }
-  }, [theme]);
+  }, [theme, customTheme?.base]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const metaTheme = document.querySelector("meta[name='theme-color']");
+
+    if (metaTheme && defaultThemeColorRef.current === null) {
+      defaultThemeColorRef.current = metaTheme.getAttribute("content");
+    }
+
+    const clearVariables = () => {
+      appliedVariablesRef.current.forEach((variable) => {
+        root.style.removeProperty(variable);
+      });
+      appliedVariablesRef.current = [];
+      if (metaTheme) {
+        const defaultThemeColor = defaultThemeColorRef.current;
+        if (defaultThemeColor && defaultThemeColor.length > 0) {
+          metaTheme.setAttribute("content", defaultThemeColor);
+        } else {
+          metaTheme.removeAttribute("content");
+        }
+      }
+    };
+
+    if (theme === "custom" && customTheme) {
+      const cssVariables = createCssVariablesFromMisskeyTheme(customTheme);
+      clearVariables();
+      Object.entries(cssVariables).forEach(([variable, value]) => {
+        root.style.setProperty(variable, value);
+      });
+      appliedVariablesRef.current = Object.keys(cssVariables);
+      if (metaTheme) {
+        const themeColor =
+          cssVariables["--background"] ?? cssVariables["--card"] ?? "";
+        if (themeColor) {
+          metaTheme.setAttribute("content", themeColor);
+        } else {
+          metaTheme.removeAttribute("content");
+        }
+      }
+      return () => {
+        clearVariables();
+      };
+    }
+
+    clearVariables();
+    return () => {
+      clearVariables();
+    };
+  }, [theme, customTheme]);
 
   const handleSetTheme = async (newTheme: Theme) => {
     if (isValidTheme(newTheme)) {
@@ -73,12 +139,43 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     }
   };
 
+  const importMisskeyTheme = async (
+    json: string,
+  ): Promise<MisskeyThemeSetting> => {
+    const parsedTheme = parseMisskeyTheme(json);
+    try {
+      await updateAppSettings({
+        customTheme: parsedTheme,
+        theme: "custom",
+      });
+    } catch (error) {
+      console.error("Failed to import Misskey theme:", error);
+      throw error;
+    }
+    return parsedTheme;
+  };
+
+  const clearCustomTheme = async () => {
+    try {
+      await updateAppSettings({
+        customTheme: undefined,
+        theme: theme === "custom" ? "system" : theme,
+      });
+    } catch (error) {
+      console.error("Failed to clear custom theme:", error);
+      throw error;
+    }
+  };
+
   return (
     <ThemeContext.Provider
       value={{
         theme,
         setTheme: handleSetTheme,
         actualTheme,
+        customTheme,
+        importMisskeyTheme,
+        clearCustomTheme,
       }}
     >
       {children}

--- a/apps/front/src/lib/theme/misskey.test.ts
+++ b/apps/front/src/lib/theme/misskey.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createCssVariablesFromMisskeyTheme,
+  parseMisskeyTheme,
+} from "./misskey";
+
+describe("parseMisskeyTheme", () => {
+  it("parses valid Misskey theme JSON", () => {
+    const json = JSON.stringify({
+      name: "Test Theme",
+      base: "dark",
+      props: {
+        accent: "#ff0000",
+        bg: "#000000",
+        fg: "#ffffff",
+      },
+    });
+
+    const theme = parseMisskeyTheme(json);
+    expect(theme).toEqual(
+      expect.objectContaining({
+        name: "Test Theme",
+        base: "dark",
+        props: {
+          accent: "#ff0000",
+          bg: "#000000",
+          fg: "#ffffff",
+        },
+      }),
+    );
+  });
+
+  it("throws an error for invalid JSON", () => {
+    expect(() => parseMisskeyTheme("not-json")).toThrowError("INVALID_JSON");
+  });
+});
+
+describe("createCssVariablesFromMisskeyTheme", () => {
+  it("creates CSS variables from Misskey theme settings", () => {
+    const theme = parseMisskeyTheme(
+      JSON.stringify({
+        name: "Sample",
+        base: "light",
+        props: {
+          accent: "#ff5722",
+          fg: "#222222",
+          bg: "#fafafa",
+          bgPanel: "#ffffff",
+          bgSub: "#f0f0f0",
+        },
+      }),
+    );
+
+    const css = createCssVariablesFromMisskeyTheme(theme);
+    expect(css["--background"]).toBe("#fafafa");
+    expect(css["--primary"]).toBe("#ff5722");
+    expect(css["--foreground"]).toBe("#222222");
+  });
+});

--- a/apps/front/src/lib/theme/misskey.ts
+++ b/apps/front/src/lib/theme/misskey.ts
@@ -1,0 +1,381 @@
+import type { MisskeyThemeSetting } from "@/lib/storage/types";
+
+type MisskeyThemeJson = {
+  name?: unknown;
+  base?: unknown;
+  author?: unknown;
+  description?: unknown;
+  props?: unknown;
+};
+
+type ParsedColor = {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+};
+
+const DEFAULT_LIGHT = {
+  background: "#ffffff",
+  foreground: "#0f172a",
+  accent: "#2563eb",
+  accentForeground: "#f8fafc",
+  border: "#e2e8f0",
+  muted: "#f1f5f9",
+  mutedForeground: "#475569",
+  destructive: "#dc2626",
+  info: "#0ea5e9",
+  warning: "#f59e0b",
+  success: "#16a34a",
+  chart1: "#f97316",
+  chart2: "#6366f1",
+  chart3: "#10b981",
+  chart4: "#8b5cf6",
+  chart5: "#facc15",
+};
+
+const DEFAULT_DARK = {
+  background: "#111827",
+  foreground: "#f9fafb",
+  accent: "#60a5fa",
+  accentForeground: "#0f172a",
+  border: "#1f2937",
+  muted: "#1f2937",
+  mutedForeground: "#94a3b8",
+  destructive: "#ef4444",
+  info: "#38bdf8",
+  warning: "#fbbf24",
+  success: "#22c55e",
+  chart1: "#fb7185",
+  chart2: "#34d399",
+  chart3: "#60a5fa",
+  chart4: "#fbbf24",
+  chart5: "#a855f7",
+};
+
+const CSS_VARIABLE_KEYS = [
+  "--background",
+  "--foreground",
+  "--card",
+  "--card-foreground",
+  "--popover",
+  "--popover-foreground",
+  "--primary",
+  "--primary-foreground",
+  "--secondary",
+  "--secondary-foreground",
+  "--muted",
+  "--muted-foreground",
+  "--accent",
+  "--accent-foreground",
+  "--destructive",
+  "--border",
+  "--input",
+  "--ring",
+  "--chart-1",
+  "--chart-2",
+  "--chart-3",
+  "--chart-4",
+  "--chart-5",
+  "--sidebar",
+  "--sidebar-foreground",
+  "--sidebar-primary",
+  "--sidebar-primary-foreground",
+  "--sidebar-accent",
+  "--sidebar-accent-foreground",
+  "--sidebar-border",
+  "--sidebar-ring",
+] as const;
+
+type CssVariableKey = (typeof CSS_VARIABLE_KEYS)[number];
+
+type CssVariableMap = Partial<Record<CssVariableKey, string>>;
+
+const HEX_PATTERN = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const RGB_PATTERN =
+  /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i;
+
+const clamp = (value: number, min = 0, max = 255) =>
+  Math.min(max, Math.max(min, value));
+
+const toHex = (value: number) => value.toString(16).padStart(2, "0");
+
+const parseHexColor = (value: string): ParsedColor | undefined => {
+  const normalized = value.trim();
+  const match = normalized.match(HEX_PATTERN);
+  if (!match) return undefined;
+  const hex = match[1];
+
+  if (hex.length === 3 || hex.length === 4) {
+    const r = Number.parseInt(hex[0] + hex[0], 16);
+    const g = Number.parseInt(hex[1] + hex[1], 16);
+    const b = Number.parseInt(hex[2] + hex[2], 16);
+    const a = hex.length === 4 ? Number.parseInt(hex[3] + hex[3], 16) / 255 : 1;
+    return { r, g, b, a };
+  }
+
+  if (hex.length === 6 || hex.length === 8) {
+    const r = Number.parseInt(hex.slice(0, 2), 16);
+    const g = Number.parseInt(hex.slice(2, 4), 16);
+    const b = Number.parseInt(hex.slice(4, 6), 16);
+    const a = hex.length === 8 ? Number.parseInt(hex.slice(6, 8), 16) / 255 : 1;
+    return { r, g, b, a };
+  }
+
+  return undefined;
+};
+
+const parseRgbColor = (value: string): ParsedColor | undefined => {
+  const match = value.trim().match(RGB_PATTERN);
+  if (!match) return undefined;
+  const [, rs, gs, bs, as] = match;
+  const r = clamp(Number.parseFloat(rs));
+  const g = clamp(Number.parseFloat(gs));
+  const b = clamp(Number.parseFloat(bs));
+  const a = as !== undefined ? clamp(Number.parseFloat(as), 0, 1) : 1;
+  return { r, g, b, a };
+};
+
+const parseColor = (value: string): ParsedColor | undefined => {
+  return parseHexColor(value) ?? parseRgbColor(value);
+};
+
+const toCssColor = ({ r, g, b, a }: ParsedColor): string => {
+  const alpha = Number(Number(a).toFixed(3));
+  if (alpha < 1) {
+    return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${alpha})`;
+  }
+  return `#${toHex(Math.round(r))}${toHex(Math.round(g))}${toHex(Math.round(b))}`;
+};
+
+const lightenColor = (value: string, amount: number): string => {
+  const color = parseColor(value);
+  if (!color) return value;
+  const { r, g, b, a } = color;
+  const lighten = (channel: number) =>
+    clamp(Math.round(channel + (255 - channel) * amount));
+  return toCssColor({ r: lighten(r), g: lighten(g), b: lighten(b), a });
+};
+
+const darkenColor = (value: string, amount: number): string => {
+  const color = parseColor(value);
+  if (!color) return value;
+  const { r, g, b, a } = color;
+  const darken = (channel: number) => clamp(Math.round(channel * (1 - amount)));
+  return toCssColor({ r: darken(r), g: darken(g), b: darken(b), a });
+};
+
+const relativeLuminance = ({ r, g, b }: ParsedColor): number => {
+  const srgb = [r, g, b].map((channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * srgb[0] + 0.7152 * srgb[1] + 0.0722 * srgb[2];
+};
+
+const getContrastColor = (value: string, fallback: string): string => {
+  const color = parseColor(value);
+  if (!color) return fallback;
+  const luminance = relativeLuminance(color);
+  return luminance > 0.55 ? "#0f172a" : "#f8fafc";
+};
+
+const normalizeProps = (
+  props: Record<string, unknown>,
+): Record<string, string> => {
+  return Object.entries(props).reduce<Record<string, string>>(
+    (acc, [key, value]) => {
+      if (typeof value === "string" && value.trim().length > 0) {
+        acc[key] = value.trim();
+      }
+      return acc;
+    },
+    {},
+  );
+};
+
+const pickColor = (
+  props: Record<string, string>,
+  keys: string[],
+  fallback: string,
+): string => {
+  for (const key of keys) {
+    const candidate = props[key];
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  return fallback;
+};
+
+export const parseMisskeyTheme = (json: string): MisskeyThemeSetting => {
+  let parsed: MisskeyThemeJson;
+  try {
+    parsed = JSON.parse(json) as MisskeyThemeJson;
+  } catch (_error) {
+    throw new Error("INVALID_JSON");
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("INVALID_DATA");
+  }
+
+  const base = parsed.base;
+  if (base !== "light" && base !== "dark") {
+    throw new Error("INVALID_BASE");
+  }
+
+  if (!parsed.props || typeof parsed.props !== "object") {
+    throw new Error("INVALID_PROPS");
+  }
+
+  const props = normalizeProps(parsed.props as Record<string, unknown>);
+  if (Object.keys(props).length === 0) {
+    throw new Error("EMPTY_PROPS");
+  }
+
+  const name =
+    typeof parsed.name === "string" && parsed.name.trim().length > 0
+      ? parsed.name.trim()
+      : "Custom Theme";
+
+  const author =
+    typeof parsed.author === "string" && parsed.author.trim().length > 0
+      ? parsed.author.trim()
+      : undefined;
+
+  const description =
+    typeof parsed.description === "string" &&
+    parsed.description.trim().length > 0
+      ? parsed.description.trim()
+      : undefined;
+
+  return {
+    name,
+    base,
+    props,
+    author,
+    description,
+  };
+};
+
+export const createCssVariablesFromMisskeyTheme = (
+  theme: MisskeyThemeSetting,
+): Record<string, string> => {
+  const isDark = theme.base === "dark";
+  const defaults = isDark ? DEFAULT_DARK : DEFAULT_LIGHT;
+  const props = normalizeProps(theme.props);
+
+  const background = pickColor(
+    props,
+    ["bg", "bgMain", "bgColor"],
+    defaults.background,
+  );
+  const foreground = pickColor(
+    props,
+    ["fg", "fgOnAccent", "fgMain", "fgColor"],
+    defaults.foreground,
+  );
+  const accent = pickColor(props, ["accent", "accentColor"], defaults.accent);
+  const accentForeground = pickColor(
+    props,
+    ["fgOnAccent", "accentFg"],
+    getContrastColor(accent, defaults.accentForeground),
+  );
+
+  const card = pickColor(
+    props,
+    ["bgPanel", "bgPanelColor", "panel"],
+    isDark ? lightenColor(background, 0.08) : darkenColor(background, 0.04),
+  );
+  const secondary = pickColor(
+    props,
+    ["bgSub", "bgHover", "bgActive"],
+    isDark ? lightenColor(background, 0.12) : darkenColor(background, 0.06),
+  );
+  const muted = pickColor(
+    props,
+    ["bgSub", "bgTransparent", "bgInactive"],
+    isDark ? lightenColor(background, 0.18) : darkenColor(background, 0.08),
+  );
+  const border = pickColor(
+    props,
+    ["bgBorder", "border", "divider"],
+    isDark ? lightenColor(background, 0.22) : darkenColor(background, 0.12),
+  );
+  const destructive = pickColor(
+    props,
+    ["danger", "warn", "error"],
+    defaults.destructive,
+  );
+  const chart1 = pickColor(props, ["cRed", "chartRed"], defaults.chart1);
+  const chart2 = pickColor(props, ["cOrange", "chartOrange"], defaults.chart2);
+  const chart3 = pickColor(props, ["cYellow", "chartYellow"], defaults.chart3);
+  const chart4 = pickColor(props, ["cGreen", "chartGreen"], defaults.chart4);
+  const chart5 = pickColor(props, ["cBlue", "chartBlue"], defaults.chart5);
+
+  const accentSubtle = pickColor(
+    props,
+    ["accentLighten", "accent2"],
+    isDark ? lightenColor(accent, 0.15) : darkenColor(accent, 0.08),
+  );
+
+  const mutedForeground = pickColor(
+    props,
+    ["fgSub", "fgMuted"],
+    isDark ? lightenColor(foreground, 0.2) : darkenColor(foreground, 0.35),
+  );
+
+  const secondaryForeground = pickColor(
+    props,
+    ["fgSub", "fg"],
+    isDark ? lightenColor(foreground, 0.12) : darkenColor(foreground, 0.2),
+  );
+
+  const sidebar = pickColor(props, ["bgPanel", "bg"], card);
+
+  const variables: CssVariableMap = {
+    "--background": background,
+    "--foreground": foreground,
+    "--card": card,
+    "--card-foreground": foreground,
+    "--popover": card,
+    "--popover-foreground": foreground,
+    "--primary": accent,
+    "--primary-foreground": accentForeground,
+    "--secondary": secondary,
+    "--secondary-foreground": secondaryForeground,
+    "--muted": muted,
+    "--muted-foreground": mutedForeground,
+    "--accent": accent,
+    "--accent-foreground": accentForeground,
+    "--destructive": destructive,
+    "--border": border,
+    "--input": border,
+    "--ring": accent,
+    "--chart-1": chart1,
+    "--chart-2": chart2,
+    "--chart-3": chart3,
+    "--chart-4": chart4,
+    "--chart-5": chart5,
+    "--sidebar": sidebar,
+    "--sidebar-foreground": foreground,
+    "--sidebar-primary": accent,
+    "--sidebar-primary-foreground": accentForeground,
+    "--sidebar-accent": accentSubtle,
+    "--sidebar-accent-foreground": accentForeground,
+    "--sidebar-border": border,
+    "--sidebar-ring": accent,
+  };
+
+  CSS_VARIABLE_KEYS.forEach((key) => {
+    const value = variables[key];
+    if (typeof value !== "string" || value.length === 0) {
+      delete variables[key];
+    }
+  });
+
+  return variables as Record<string, string>;
+};
+
+export const MISSKEY_THEME_VARIABLE_KEYS: string[] = [...CSS_VARIABLE_KEYS];

--- a/apps/front/src/locales/en/settings.json
+++ b/apps/front/src/locales/en/settings.json
@@ -13,11 +13,41 @@
     "english": "English"
   },
   "theme": {
-    "title": "Dark Mode",
-    "description": "Switch the app appearance to dark theme",
+    "title": "Theme",
+    "description": "Switch the application's color theme and mode",
     "light": "Light",
     "dark": "Dark",
-    "system": "System"
+    "system": "System",
+    "custom": "Custom",
+    "import": {
+      "title": "Import Misskey Theme",
+      "description": "Use a Misskey theme JSON to recolor the entire app.",
+      "placeholder": "Paste the Misskey theme JSON here",
+      "button": "Apply JSON",
+      "processing": "Applying...",
+      "upload": "Choose theme file",
+      "clearButton": "Reset custom theme",
+      "clearTitle": "Custom theme cleared",
+      "clearDescription": "Reverted to the default theme settings.",
+      "successTitle": "Theme applied",
+      "successDescription": "Applied {{name}}.",
+      "errorTitle": "Failed to load theme",
+      "current": "Current custom theme: {{name}} ({{base}})",
+      "noTheme": "No custom theme has been applied yet.",
+      "base": {
+        "light": "Light",
+        "dark": "Dark"
+      },
+      "errors": {
+        "required": "Please provide the theme JSON.",
+        "invalidJson": "The JSON format is invalid.",
+        "invalidData": "The theme structure is invalid.",
+        "invalidBase": "The theme \"base\" must be either \"light\" or \"dark\".",
+        "invalidProps": "The theme does not include valid color settings.",
+        "emptyProps": "No usable color values were found in the theme.",
+        "unknown": "An unexpected error occurred while applying the theme."
+      }
+    }
   },
   "notifications": {
     "title": "Notifications",

--- a/apps/front/src/locales/ja/settings.json
+++ b/apps/front/src/locales/ja/settings.json
@@ -13,11 +13,41 @@
     "english": "English"
   },
   "theme": {
-    "title": "ダークモード",
-    "description": "アプリの外観をダークテーマに切り替えます",
+    "title": "テーマ",
+    "description": "アプリ全体の配色とモードを切り替えます",
     "light": "ライト",
     "dark": "ダーク",
-    "system": "システム"
+    "system": "システム",
+    "custom": "カスタム",
+    "import": {
+      "title": "Misskeyテーマをインポート",
+      "description": "MisskeyのテーマJSONを読み込んでアプリ全体の配色を変更します。",
+      "placeholder": "MisskeyテーマのJSONをここに貼り付けてください",
+      "button": "JSONを適用",
+      "processing": "適用中...",
+      "upload": "テーマファイルを選択",
+      "clearButton": "カスタムテーマをリセット",
+      "clearTitle": "カスタムテーマをリセットしました",
+      "clearDescription": "標準のテーマ設定に戻りました。",
+      "successTitle": "テーマを適用しました",
+      "successDescription": "{{name}} を適用しました。",
+      "errorTitle": "テーマの読み込みに失敗しました",
+      "current": "現在のカスタムテーマ: {{name}}（{{base}}）",
+      "noTheme": "カスタムテーマは設定されていません。",
+      "base": {
+        "light": "ライト",
+        "dark": "ダーク"
+      },
+      "errors": {
+        "required": "テーマJSONを入力してください。",
+        "invalidJson": "JSONの形式が正しくありません。",
+        "invalidData": "テーマの構造が正しくありません。",
+        "invalidBase": "テーマの\"base\"は\"light\"または\"dark\"である必要があります。",
+        "invalidProps": "テーマに有効な色設定が含まれていません。",
+        "emptyProps": "テーマに有効な色設定が含まれていません。",
+        "unknown": "テーマの適用中に不明なエラーが発生しました。"
+      }
+    }
   },
   "notifications": {
     "title": "通知",


### PR DESCRIPTION
## Summary
- add a Misskey theme importer in application settings and expose a custom theme toggle
- parse Misskey theme JSON, convert it to CSS variables, and apply it through the theme provider
- persist custom theme data, translate the new UI, set a default theme-color, and cover the converter with tests

## Testing
- pnpm -F @mi-deck/front test *(fails: existing suite stops at `src/features/mfm/components/MfmText.test.tsx` because `@mi-deck/react-mfm` has no resolvable entry point)*

------
https://chatgpt.com/codex/tasks/task_e_68e234b38c4883279c2baa8309dd7517